### PR TITLE
forbid spaces in the middle of a domain name

### DIFF
--- a/domaincheck.go
+++ b/domaincheck.go
@@ -28,6 +28,11 @@ func Valid(domain string) bool {
 		return false
 	}
 
+	// should not contain spaces anywhere
+	if strings.Contains(domain, " ") {
+		return false
+	}
+
 	tokens := strings.Split(domain, ".")
 	// should have at least two tokens
 	if len(tokens) < 2 {

--- a/domaincheck_test.go
+++ b/domaincheck_test.go
@@ -37,6 +37,7 @@ var (
 		"bad.   .example.com",
 		"bad. www  .example.com",
 		"bad.www\t.example.com",
+		"bad.with spaces in middle.com",
 		"..invalid",
 		"invalid-too",
 		"com",


### PR DESCRIPTION
currently it only checks for spaces before or after a `.` 